### PR TITLE
Update concepts.md

### DIFF
--- a/docs/guide/concepts.md
+++ b/docs/guide/concepts.md
@@ -1,49 +1,58 @@
 # What is ParaView Catalyst?
 
-ParaView Catalyst is an open-source software framework that empowers your simulations with cutting-edge in situ visualization and analysis capabilities, all while minimizing disruptions to your existing code.  Its flexible, high-performance architecture enables in situ analysis on everything from desktop workstations to the most advanced exascale supercomputers, leveraging both CPUs and GPUs to deliver real-time, insight-rich visualizations that drive discovery and innovation.
+ParaView Catalyst lets you run visualization and analysis pipelines inside your simulation while it's running, instead of writing data to disk and post-processing later. Your simulation passes its mesh and field data to Catalyst at each timestep. Catalyst hands that data to a ParaView-based backend that runs whatever analysis you've configured (rendering images, extracting features, computing statistics, writing reduced datasets) then returns control to your simulation.
+
+## The Five API Calls
+
+Your simulation interacts with Catalyst through five C functions (with C++, Python, and Fortran wrappers):
+
+- **`catalyst_initialize`**: Load pipeline scripts and configure the backend. Called once at startup.
+- **`catalyst_execute`**: Pass mesh and field data for one timestep. Called every iteration (or as often as you choose).
+- **`catalyst_results`**: Read back values produced by the pipeline (e.g., corrected fields for closed-loop workflows). Called after execute when the simulation needs output from the analysis.
+- **`catalyst_finalize`**: Shut down Catalyst and free resources. Called once at the end.
+- **`catalyst_about`**: Query version and capability information.
+
+Each function takes a [Conduit](https://llnl-conduit.readthedocs.io/en/latest/) node as its argument.
+
+## How Data Flows
+
+Your simulation owns its data. The adaptor describes the memory layout to Catalyst using a Conduit node, typically with `set_external`, which passes pointers without copying. Catalyst routes that description to the ParaView backend, which builds VTK data objects from the pointers and runs the pipeline. Results (images, meshes, statistics, or field corrections) are produced without the simulation ever writing full timestep data to disk.
+
+![Catalyst Solution](/assets/images/guide/concepts/concept-solution.png)
+
+## Conduit and Mesh Blueprint
+
+[Conduit](https://llnl-conduit.readthedocs.io/en/latest/) is the data description layer, developed by Lawrence Livermore National Laboratory. It provides a lightweight hierarchical container, essentially a runtime JSON structure that can hold pointers to your simulation's existing arrays. You don't copy data into Conduit; you describe where it already lives in memory.
+
+[Mesh Blueprint](https://llnl-conduit.readthedocs.io/en/latest/blueprint_mesh.html) is the schema that both sides agree on. It defines conventions for representing coordinate sets, topologies (structured, unstructured, polyhedral), and fields. When your adaptor writes `mesh["topologies/mesh/type"] = "unstructured"`, the ParaView backend knows exactly how to interpret the connectivity array that follows.
+
+## Channels
+
+A channel is a named data port. Most simulations use a single channel (e.g., "grid"), but you can define multiple channels to separate different mesh regions. For example, a "volume" channel for the full 3D field and a "surface" channel for boundary data. Each channel carries its own Conduit node with its own coordinate set, topology, and fields.
+
+## The Runtime Loading Model
+
+Your simulation links against `libcatalyst` at build time, a small stub library with no ParaView dependency. At runtime, `catalyst_initialize` loads the actual backend (e.g., `libcatalyst-paraview.so`) via dynamic loading, based on environment variables or Conduit node metadata. This means your simulation binary has no compile-time dependency on ParaView, and you can swap backends or run without one entirely, without rebuilding.
+
+## Pipeline Scripts
+
+The analysis to run at each timestep is defined in Python scripts that implement `catalyst_execute(info)`. You point Catalyst to these scripts at initialize time, either through the Conduit node or via command-line arguments in your adaptor. The scripts use the full ParaView Python API, so anything you can do interactively in ParaView, you can do in a Catalyst pipeline script.
+
+You can write scripts by hand or generate them from the ParaView GUI using **File → Save Catalyst State**, which captures your current pipeline and extractors as a ready-to-use Catalyst script.
+
+## Why In Situ?
+
+In conventional post-processing, the simulation writes timestep data to disk so that visualization tools can process it after the run completes. This creates two problems: I/O is orders of magnitude slower than computation, and the resulting files are large enough that users typically save only a fraction of the timesteps they'd like to analyze.
+
+![I/O Bottleneck](/assets/images/guide/concepts/concept-bottleneck.png)
+
+The in situ approach removes the bottleneck by performing analysis on data that is already in memory. The simulation still produces outputs (images, reduced datasets, extracted features) but these are far smaller than full timestep dumps. More timesteps can be analyzed in less time.
+
+![I/O Solution](/assets/images/guide/concepts/concept-io.png)
 
 <figure>
     <video control loop autoplay>
         <source src="/assets/images/guide/concepts/CatalystBallVideo1.mp4" alt="Rolling Ball Simulation">
     </video>
-    <figcaption>Comparing Traditional Post-Processing (left) to In situ visualization using ParaView Catalyst (right).</figcaption>
+    <figcaption>Comparing traditional post-processing (left) to in situ visualization using ParaView Catalyst (right).</figcaption>
 </figure>
-
-Built upon the foundation of our award-winning ParaView architecture, ParaView Catalyst dramatically reduces the input/output (I/O) bottleneck that is commonly associated with traditional post-processing techniques.
-
-By integrating visualization and analysis directly into your simulation workflow, ParaView Catalyst enables you to extract insights and understanding from your data in real time, without the need for time-consuming and resource-intensive data transfer and storage. This in situ approach not only accelerates your overall workflow but also opens up new possibilities for interactive exploration and steering of your simulations.
-
-With its flexible and extensible design, ParaView Catalyst can be readily adapted to a wide range of simulation codes and computing environments. Whether you're working on a small-scale desktop simulation or a large-scale high-performance computing cluster, ParaView Catalyst can provide you with the tools you need to visualize and analyze your data in a way that is both efficient and effective.
-
-## What is the I/O Bottleneck?
-
-In conventional post-processing approaches, the simulation will write out the information it wants processed to disk so that the post-processing tools can visualize it after the simulation has ended.  This can significantly impact the simulation performance since I/O is orders of magnitude slower than the CPU or GPU cores being used by the simulation.  In addition, the information associated with each timestep can be quite large.  As a result, the simulation user typically will reduce the number of timesteps that are saved to disk which will impact the fidelity of the post-processed results. 
-
-![I/O Bottleneck](/assets/images/guide/concepts/concept-bottleneck.png)
-
-## Attacking the I/O Problem
-
-The in situ approach used by ParaView Catalyst addresses the I/O issue by performing the post-processing using the simulation in core; hence removing  the need to write out timesteps to disk.  This does not completely eliminate I/O associated with post-processing since the visualization information does need to be saved; however, the information associated with the post-processed result is significantly less than the original timestep information. This will allow the simulation to analyze more timesteps than the conventional approach in less time as shown in the video above.
-
-![I/O Problem](/assets/images/guide/concepts/concept-io.png)
-
-
-## How Does ParaView Catalyst Interface With the Simulation?
-
-### Introducing Catalyst, Conduit, and Mesh Blueprint
-Your simulation code itself will not know about ParaView Catalyst but will be using a small easy to use library called Catalyst.  The [Catalyst library](https://gitlab.kitware.com/paraview/catalyst) is written in C but also provides C++, Python, and FORTRAN wrappings.  It provides the routines to initialize and finalize Catalyst as well as a routine to execute  the processing of a timestep.
-
-For representing the data associated with the simulation, Catalyst uses Conduit.  Conduit, an open-source project developed by Lawrence Livermore National Laboratory, offers an intuitive model for representing hierarchical scientific data in C++, C, FORTRAN, and Python. Its applications include in-core data coupling between packages, serialization, and I/O operations.
-
-Using Conduit, you can describe the structure of key pieces of the simulation.  For example, how are the points, mesh elements, and fields represented.  In most cases, this will not involve any data duplication and thereby will not impact the simulation’s memory footprint.
-
-### So where does ParaView Catalyst come in?
-
-ParaView Catalyst is an implemented backend for Catalyst and is dynamically loaded at runtime.  You will typically pass or hardwire a Python script describing the visualization/analysis you want performed when you initialized Catalyst and the backend will do all of the work for each timestep you execute.
-
-
-![Catalyst Solution](/assets/images/guide/concepts/concept-solution.png)
-
-### Making sure the simulation and the Catalyst Backend are on the same page - Mesh Blueprint
-
-We have said that Conduit provides a flexible representation used to bridge between the solver and the Catalyst Backend, but how do we guarantee  that the backend is interpreting the representation correctly?  To ensure the Catalyst Backend correctly deciphers the flexible representation provided by Conduit, both sides must agree on and utilize a schema alongside the Conduit representation. In the case of ParaView Catalyst, the Mesh Blueprint specification fulfills this role.


### PR DESCRIPTION
Replaced the marketing-oriented introduction with a developer-focused overview of how Catalyst actually works. The page now covers the five API calls (including catalyst_results, which was previously undocumented here), data flow, Conduit/Mesh Blueprint, channels, the runtime loading model, and pipeline scripts. Moved the I/O bottleneck motivation to the end of the page for readers who need it, rather than leading with it. No asset changes.